### PR TITLE
Add cartdata support, for persistent storage

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -141,9 +141,10 @@ function _load(filename)
 	for i=0, 0x1c00-1 do
 		pico8.usermemory[i]=0
 	end
-	for i=0, 63 do
+	for i=1, 64 do
 		pico8.cartdata[i]=0
 	end
+	pico8.cart_id=false
 	if pico8.cart._init then pico8.cart._init() end
 	if pico8.cart._update60 then
 		setfps(60)


### PR DESCRIPTION
I'm not at all sure this is the best approach, but it's a naive attempt.

I made some choices:

- Used LÖVE 11's new [love.data.pack](https://love2d.org/wiki/love.data.pack)/[love.data.unpack](https://love2d.org/wiki/love.data.unpack) functions (there are a million other serializing libraries, but I opted for this to use a built-in)
- Changed internal cartdata table to a 1-indexed sequence, to make it easier to pack/unpack it
- Made `cartdata()` set up a LÖVE save file in a common "picolove" directory (this choice was already made in the config) with the cartdata id as a filename, to mirror PICO-8's setup and make it possible for carts to share cartdata
- `dget()` loads the entire cartdata each time, to make sure we're always reading from the persistent storage (is this necessary unless we want to support multiple carts accessing memory at the same time?)
- `dset()` saves the entire cartdata each time (this is probably necessary)
- `peek()`/`poke()` at persistent memory now calls `dget()`/`dset()`, which means there's some overhead but I'm not sure we can escape it

There might be more efficient ways to do the serializing and file handling. I'm pretty new to LÖVE. We could perhaps even do away with the serializing and the entire `pico8.cartdata` table now that it's just a transparent cache, and scan to the correct location in the file every time instead... Suggestions welcome.