### PR TITLE
basic fillp(), support for tabled palettes in pal(), support for custom menuitem()

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1176,7 +1176,19 @@ function api.holdframe()
 	-- TODO: Implement this
 end
 
-function api.menuitem()
+function api.menuitem(index,label,callback)
+  if not index or index<1 or index >5 then return end
+  if label==nil or callback==nil then
+    pico8.custom_menu[index] = nil
+  else
+    pico8.custom_menu[index] = {string.sub(label,1,16), callback}
+  end
+
+  local tot=0
+  for i=1,5 do
+    if pico8.custom_menu[i]~=nil then tot=tot+1 end
+  end
+  pico8.custom_menu[0] = tot
 end
 
 api.sub=string.sub


### PR DESCRIPTION
I implemented a basic fillp that for now supports patterns in color+black or color+transparent, for now it's only applied to draw_shader, none of the new sprite patterns etc.. Also it doesn't set anything in the draw state since it's not implemented.

In addition I added support for palette in tables passed to pal() such as pal({1,2,3,4,5,6,7,8,9,10,...}) to remap multiple colors at once as I used it a lot in my games, and cleaned up a bit all shaders settings in pal()

I have a couple "in progress" things left to add, then I'll take a break to work on my next game and after that continue this so it supports at least my other games